### PR TITLE
break: move to `varint` to describe log's content length

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -8,3 +8,5 @@ popd
 pushd android
 sh b_android.sh
 popd
+
+cargo clippy --workspace --all-features

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,9 +4,11 @@ use std::io::{BufReader, BufWriter, Cursor, Read};
 use std::thread;
 use std::time::Duration;
 
+use ezlog::EZLogger;
+use ezlog::Level;
 use ezlog::{
-    create_log, CipherKind, CompressKind, EZLogCallback, EZLogConfig, EZLogConfigBuilder, EZLogger,
-    EZRecord, EventPrinter, Header,
+    create_log, CipherKind, CompressKind, EZLogCallback, EZLogConfig, EZLogConfigBuilder, EZRecord,
+    EventPrinter, Header,
 };
 use log::{debug, error, info, trace, warn, LevelFilter};
 use log::{Metadata, Record};
@@ -50,7 +52,7 @@ fn get_config() -> EZLogConfig {
     let key = b"an example very very secret key.";
     let nonce = b"unique nonce";
     EZLogConfigBuilder::new()
-        .level(ezlog::Level::Trace)
+        .level(Level::Trace)
         .dir_path(
             dirs::download_dir()
                 .unwrap()

--- a/ezlog-cli/src/main.rs
+++ b/ezlog-cli/src/main.rs
@@ -160,6 +160,7 @@ pub fn main() {
     EZLogger::decode_body_and_write(
         &mut buf_reader,
         &mut plain_text_write,
+        &config.version,
         &compression,
         &decryptor,
     )

--- a/ezlog-core/Cargo.toml
+++ b/ezlog-core/Cargo.toml
@@ -32,6 +32,7 @@ thread-id = "4.0.0"
 once_cell = "1.12"
 thiserror = "1"
 backtrace = { version = "0.3", optional = true}
+integer-encoding = "3.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.20.0"

--- a/ezlog-core/src/appender.rs
+++ b/ezlog-core/src/appender.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use time::OffsetDateTime;
 
-use crate::*;
+use crate::{logger::Header, *};
 
 pub trait AppenderInner: Write {
     fn is_oversize(&self, buf_size: usize) -> bool;
@@ -361,7 +361,7 @@ impl Write for NopInner {
 #[cfg(test)]
 mod tests {
 
-    use std::fs::{File, OpenOptions};
+    use std::fs::{self, File, OpenOptions};
     use std::io::{BufReader, Seek, SeekFrom};
 
     use crate::config::EZLogConfigBuilder;

--- a/ezlog-core/src/config.rs
+++ b/ezlog-core/src/config.rs
@@ -235,7 +235,7 @@ impl EZLogConfigBuilder {
         EZLogConfigBuilder {
             config: EZLogConfig {
                 level: Level::Trace,
-                version: Version::V1,
+                version: Version::V2,
                 dir_path: "".to_string(),
                 name: DEFAULT_LOG_NAME.to_string(),
                 file_suffix: DEFAULT_LOG_FILE_SUFFIX.to_string(),

--- a/ezlog-core/src/ffi_c.rs
+++ b/ezlog-core/src/ffi_c.rs
@@ -1,6 +1,8 @@
 use libc::c_void;
 
+use crate::config::Level;
 use crate::events::EventPrinter;
+use crate::recorder::EZRecordBuilder;
 use crate::*;
 use core::slice;
 use libc::c_char;

--- a/ezlog-core/src/ffi_java.rs
+++ b/ezlog-core/src/ffi_java.rs
@@ -8,7 +8,7 @@ use jni::{
     signature::Primitive,
     strings::JNIString,
     sys::{jboolean, jbyteArray, jint, jobject, jobjectArray, jvalue, JNI_VERSION_1_6},
-    JNIEnv, JavaVM, AttachGuard,
+    AttachGuard, JNIEnv, JavaVM,
 };
 use libc::c_void;
 use once_cell::sync::OnceCell;

--- a/ezlog-core/src/logger.rs
+++ b/ezlog-core/src/logger.rs
@@ -1,0 +1,428 @@
+use byteorder::{BigEndian, WriteBytesExt};
+use integer_encoding::VarIntWriter;
+use std::io::Read;
+use std::path::PathBuf;
+use std::{fs, io};
+use std::{io::Write, rc::Rc};
+#[cfg(feature = "decode")]
+use std::io::BufRead;
+
+use crate::Version;
+use crate::{
+    appender::EZAppender,
+    compress::ZlibCodec,
+    crypto::{Aes128Gcm, Aes256Gcm},
+    errors::LogError,
+    CipherKind, Compress, CompressKind, Cryptor, EZLogConfig, EZRecord, RECORD_SIGNATURE_END,
+    RECORD_SIGNATURE_START,
+};
+use crate::{errors, event, V1_LOG_HEADER_SIZE};
+use byteorder::ReadBytesExt;
+use time::format_description::well_known::Rfc3339;
+use time::Date;
+#[cfg(feature = "decode")]
+use integer_encoding::VarIntReader;
+
+type Result<T> = std::result::Result<T, LogError>;
+
+pub struct EZLogger {
+    pub config: Rc<EZLogConfig>,
+    pub appender: Box<dyn Write>,
+    compression: Option<Box<dyn Compress>>,
+    cryptor: Option<Box<dyn Cryptor>>,
+}
+
+impl EZLogger {
+    pub fn new(config: EZLogConfig) -> Result<Self> {
+        let rc_conf = Rc::new(config);
+        let appender = Box::new(EZAppender::new(Rc::clone(&rc_conf))?);
+        let compression = EZLogger::create_compress(&rc_conf);
+        let cryptor = EZLogger::create_cryptor(&rc_conf)?;
+
+        Ok(Self {
+            config: Rc::clone(&rc_conf),
+            appender,
+            compression,
+            cryptor,
+        })
+    }
+
+    pub fn create_cryptor(config: &EZLogConfig) -> Result<Option<Box<dyn Cryptor>>> {
+        if let Some(key) = &config.cipher_key {
+            if let Some(nonce) = &config.cipher_nonce {
+                match config.cipher {
+                    CipherKind::AES128GCM => {
+                        let encryptor = Aes128Gcm::new(key, nonce)?;
+                        Ok(Some(Box::new(encryptor)))
+                    }
+                    CipherKind::AES256GCM => {
+                        let encryptor = Aes256Gcm::new(key, nonce)?;
+                        Ok(Some(Box::new(encryptor)))
+                    }
+                    CipherKind::NONE => Ok(None),
+                    CipherKind::UNKNOWN => Ok(None),
+                }
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn create_compress(config: &EZLogConfig) -> Option<Box<dyn Compress>> {
+        match config.compress {
+            CompressKind::ZLIB => Some(Box::new(ZlibCodec::new(&config.compress_level))),
+            CompressKind::NONE => None,
+            CompressKind::UNKNOWN => None,
+        }
+    }
+
+    pub(crate) fn append(&mut self, record: &EZRecord) -> Result<()> {
+        let mut e: Option<LogError> = None;
+        if record.content().len() > self.config.max_size as usize / 2 {
+            record.trunks(&self.config).iter().for_each(|record| {
+                match self.encode_as_block(record) {
+                    Ok(buf) => match self.appender.write_all(&buf) {
+                        Ok(_) => {}
+                        Err(err) => e = Some(LogError::IoError(err)),
+                    },
+                    Err(err) => {
+                        e = Some(err);
+                    }
+                }
+            })
+        } else {
+            let buf = self.encode_as_block(record)?;
+            self.appender.write_all(&buf)?;
+        }
+        if let Some(err) = e {
+            Err(err)
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn encode(&mut self, record: &EZRecord) -> Result<Vec<u8>> {
+        let mut buf = self.format(record);
+        if let Some(encryptor) = &self.cryptor {
+            event!(encrypt_start & record.t_id());
+            buf = encryptor.encrypt(&buf)?;
+            event!(encrypt_end & record.t_id());
+        }
+        if let Some(compression) = &self.compression {
+            event!(compress_start & record.t_id());
+            buf = compression.compress(&buf).map_err(LogError::Compress)?;
+            event!(compress_end & record.t_id());
+        }
+        Ok(buf)
+    }
+
+    ///
+    #[inline]
+    pub fn encode_as_block(&mut self, record: &EZRecord) -> Result<Vec<u8>> {
+        let buf = self.encode(record)?;
+        Self::encode_content(buf)
+    }
+
+    #[inline]
+    pub(crate) fn encode_content(mut buf: Vec<u8>) -> Result<Vec<u8>> {
+        let mut chunk: Vec<u8> = Vec::new();
+        chunk.push(RECORD_SIGNATURE_START);
+        let size = buf.len();
+        let mut size_chunk = Self::create_size_chunk(size)?;
+        chunk.append(&mut size_chunk);
+        chunk.append(&mut buf);
+        chunk.push(RECORD_SIGNATURE_END);
+        Ok(chunk)
+    }
+
+    #[inline]
+    pub(crate) fn create_size_chunk(size: usize) -> Result<Vec<u8>> {
+        let mut chunk: Vec<u8> = Vec::new();
+        chunk.write_varint(size)?;
+        Ok(chunk)
+    }
+
+    #[inline]
+    #[cfg(feature = "decode")]
+    pub fn decode_record(&mut self, reader: &mut dyn BufRead) -> Result<Vec<u8>> {
+        Self::decode_record_from_read(
+            reader,
+            &self.config.version,
+            &self.compression,
+            &self.cryptor,
+        )
+    }
+
+    #[inline]
+    #[cfg(feature = "decode")]
+    pub fn decode_body_and_write(
+        reader: &mut dyn BufRead,
+        writer: &mut dyn Write,
+        version: &Version,
+        compression: &Option<Box<dyn Compress>>,
+        cryptor: &Option<Box<dyn Cryptor>>,
+    ) -> io::Result<()> {
+        loop {
+            match Self::decode_record_from_read(reader, version, compression, cryptor) {
+                Ok(buf) => {
+                    if buf.is_empty() {
+                        break;
+                    }
+                    writer.write_all(&buf)?;
+                }
+                Err(e) => match e {
+                    LogError::IoError(err) => {
+                        if err.kind() == io::ErrorKind::UnexpectedEof {
+                            break;
+                        }
+                    }
+                    LogError::IllegalArgument(_) => break,
+                    _ => continue,
+                },
+            }
+        }
+        writer.flush()
+    }
+
+    #[cfg(feature = "decode")]
+    pub(crate) fn decode_record_from_read(
+        reader: &mut dyn BufRead,
+        version: &Version,
+        compression: &Option<Box<dyn Compress>>,
+        cryptor: &Option<Box<dyn Cryptor>>,
+    ) -> Result<Vec<u8>> {
+        let chunk = Self::decode_record_to_content(reader, version)?;
+        Self::decode_record_content(&chunk, compression, cryptor)
+    }
+
+    #[inline]
+    #[cfg(feature = "decode")]
+    pub(crate) fn decode_record_to_content(
+        reader: &mut dyn BufRead,
+        version: &Version,
+    ) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        let nums = reader.read_until(RECORD_SIGNATURE_START, &mut buf)?;
+        if nums == 0 {
+            return Err(LogError::IllegalArgument(
+                "has no record start signature".to_string(),
+            ));
+        }
+        let content_size: usize = Self::decode_record_size(reader, version)?;
+        let mut chunk = vec![0u8; content_size];
+        reader.read_exact(&mut chunk)?;
+        let end_sign = reader.read_u8()?;
+        if RECORD_SIGNATURE_END != end_sign {
+            return Err(LogError::Parse("record end sign error".to_string()));
+        }
+        Ok(chunk)
+    }
+
+    #[inline]
+    #[cfg(feature = "decode")]
+    pub(crate) fn decode_record_size(
+        mut reader: &mut dyn BufRead,
+        version: &Version,
+    ) -> Result<usize> {
+        match version {
+            Version::V1 => {
+                let size_of_size = reader.read_u8()?;
+                let content_size: usize = match size_of_size {
+                    1 => reader.read_u8()? as usize,
+                    2 => reader.read_u16::<BigEndian>()? as usize,
+                    _ => reader.read_u32::<BigEndian>()? as usize,
+                };
+                Ok(content_size)
+            }
+            Version::V2 => {
+                let size: usize = reader.read_varint()?;
+                Ok(size)
+            }
+            Version::UNKNOWN => Err(LogError::IllegalArgument(format!(
+                "unknow version {:?}",
+                version
+            ))),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "decode")]
+    pub fn decode_record_content(
+        chunk: &[u8],
+        compression: &Option<Box<dyn Compress>>,
+        cryptor: &Option<Box<dyn Cryptor>>,
+    ) -> Result<Vec<u8>> {
+        let mut buf = chunk.to_vec();
+
+        if let Some(decompression) = compression {
+            buf = decompression.decompress(&buf)?;
+        }
+
+        if let Some(decryptor) = cryptor {
+            buf = decryptor.decrypt(&buf)?;
+        }
+        Ok(buf)
+    }
+
+    fn format(&self, record: &EZRecord) -> Vec<u8> {
+        let time = record
+            .time()
+            .format(&Rfc3339)
+            .unwrap_or_else(|_| "unknown".to_string());
+        format!(
+            "\n{} {} {} [{}:{}] {}",
+            time,
+            record.level(),
+            record.target(),
+            record.thread_name(),
+            record.thread_id(),
+            record.content()
+        )
+        .into_bytes()
+    }
+
+    pub(crate) fn flush(&mut self) -> std::result::Result<(), io::Error> {
+        self.appender.flush()
+    }
+
+    pub(crate) fn trim(&self) {
+        match fs::read_dir(&self.config.dir_path) {
+            Ok(dir) => {
+                for file in dir {
+                    match file {
+                        Ok(file) => {
+                            if let Some(name) = file.file_name().to_str() {
+                                match self.config.is_file_out_of_date(name) {
+                                    Ok(out_of_date) => {
+                                        if out_of_date {
+                                            fs::remove_file(file.path()).unwrap_or_else(|e| {
+                                                event!(
+                                                    trim_logger_err
+                                                        & format!("trim: remove file err: {}", e)
+                                                )
+                                            });
+                                        }
+                                    }
+                                    Err(e) => {
+                                        event!(
+                                            trim_logger_err
+                                                & format!(
+                                                    "trim: judge file out of date error: {}",
+                                                    e
+                                                )
+                                        )
+                                    }
+                                }
+                            };
+                        }
+                        Err(e) => {
+                            event!(trim_logger_err & format!("trim: traversal file error: {}", e))
+                        }
+                    }
+                }
+            }
+            Err(e) => event!(trim_logger_err & format!("trim: read dir error: {}", e)),
+        }
+    }
+
+    pub fn query_log_files_for_date(&self, date: Date) -> Vec<PathBuf> {
+        self.config.query_log_files_for_date(date)
+    }
+}
+
+/// EZLog file Header
+///
+/// every log file starts with a header,
+/// which is used to describe the version, log length, compress type, cipher kind and so on.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Header {
+    /// version code
+    pub(crate) version: Version,
+    /// unused flag
+    pub(crate) flag: u8,
+    /// current log file write position
+    pub(crate) recorder_position: u32,
+    /// compress type
+    pub(crate) compress: CompressKind,
+    /// cipher kind
+    pub(crate) cipher: CipherKind,
+}
+
+impl Default for Header {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Header {
+    pub fn new() -> Self {
+        Header {
+            version: Version::V1,
+            flag: 0,
+            recorder_position: Header::fixed_size() as u32,
+            compress: CompressKind::ZLIB,
+            cipher: CipherKind::AES128GCM,
+        }
+    }
+
+    pub fn create(config: &EZLogConfig) -> Self {
+        Header {
+            version: config.version,
+            flag: 0,
+            recorder_position: Header::fixed_size() as u32,
+            compress: config.compress,
+            cipher: config.cipher,
+        }
+    }
+
+    pub fn fixed_size() -> usize {
+        V1_LOG_HEADER_SIZE
+    }
+
+    pub fn encode(&self, writer: &mut dyn Write) -> std::result::Result<(), io::Error> {
+        writer.write_all(crate::FILE_SIGNATURE)?;
+        writer.write_u8(self.version.into())?;
+        writer.write_u8(self.flag)?;
+        writer.write_u32::<BigEndian>(self.recorder_position)?;
+        writer.write_u8(self.compress.into())?;
+        writer.write_u8(self.cipher.into())
+    }
+
+    pub fn decode(reader: &mut dyn Read) -> std::result::Result<Self, errors::LogError> {
+        let mut signature = [0u8; 2];
+        reader.read_exact(&mut signature)?;
+        let version = reader.read_u8()?;
+        let flag = reader.read_u8()?;
+        let mut recorder_size = reader.read_u32::<BigEndian>()?;
+        if recorder_size < Header::fixed_size() as u32 {
+            recorder_size = Header::fixed_size() as u32;
+        }
+
+        let compress = reader.read_u8()?;
+        let cipher = reader.read_u8()?;
+        Ok(Header {
+            version: Version::from(version),
+            flag,
+            recorder_position: recorder_size,
+            compress: CompressKind::from(compress),
+            cipher: CipherKind::from(cipher),
+        })
+    }
+
+    pub fn is_valid(&self, config: &EZLogConfig) -> bool {
+        self.version == config.version
+            && self.compress == config.compress
+            && self.cipher == config.cipher
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.version == Version::UNKNOWN && self.recorder_position <= Header::fixed_size() as u32
+    }
+
+    pub fn version(&self) -> &Version {
+        &self.version
+    }
+}

--- a/ezlog-core/src/recorder.rs
+++ b/ezlog-core/src/recorder.rs
@@ -1,0 +1,234 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    thread,
+};
+
+use crate::{EZLogConfig, Level, DEFAULT_LOG_NAME};
+#[cfg(feature = "log")]
+use log::Record;
+use time::OffsetDateTime;
+
+/// Single Log record
+#[derive(Debug, Clone)]
+pub struct EZRecord {
+    id: u64,
+    log_name: String,
+    level: Level,
+    target: String,
+    time: OffsetDateTime,
+    thread_id: usize,
+    thread_name: String,
+    content: String,
+}
+
+impl EZRecord {
+    #[inline]
+    pub fn builder() -> EZRecordBuilder {
+        EZRecordBuilder::new()
+    }
+
+    #[inline]
+    pub fn level(&self) -> Level {
+        self.level
+    }
+
+    #[inline]
+    pub fn target(&self) -> &str {
+        self.target.as_str()
+    }
+
+    #[inline]
+    pub fn timestamp(&self) -> i64 {
+        self.time.unix_timestamp()
+    }
+
+    #[inline]
+    pub fn thread_id(&self) -> usize {
+        self.thread_id
+    }
+
+    #[inline]
+    pub fn thread_name(&self) -> &str {
+        self.thread_name.as_str()
+    }
+
+    #[inline]
+    pub fn content(&self) -> &str {
+        self.content.as_str()
+    }
+
+    pub fn log_name(&self) -> &str {
+        &self.log_name
+    }
+
+    pub fn time(&self) -> &OffsetDateTime {
+        &self.time
+    }
+
+    #[inline]
+    pub fn to_builder(&self) -> EZRecordBuilder {
+        EZRecordBuilder {
+            record: EZRecord {
+                id: self.id,
+                log_name: self.log_name.clone(),
+                level: self.level,
+                target: self.target.clone(),
+                time: self.time,
+                thread_id: self.thread_id,
+                thread_name: self.thread_name.clone(),
+                content: self.content.clone(),
+            },
+        }
+    }
+
+    #[inline]
+    pub fn to_trunk_builder(&self) -> EZRecordBuilder {
+        EZRecordBuilder {
+            record: EZRecord {
+                id: 0,
+                log_name: self.log_name.clone(),
+                level: self.level,
+                target: self.target.clone(),
+                time: self.time,
+                thread_id: self.thread_id,
+                thread_name: self.thread_name.clone(),
+                content: "".into(),
+            },
+        }
+    }
+
+    #[cfg(feature = "log")]
+    pub fn from(r: &Record) -> Self {
+        let t = thread::current();
+        let t_id = thread_id::get();
+        let t_name = t.name().unwrap_or_default();
+        EZRecordBuilder::new()
+            .log_name(DEFAULT_LOG_NAME.to_string())
+            .level(r.metadata().level().into())
+            .target(r.target().to_string())
+            .time(OffsetDateTime::now_utc())
+            .thread_id(t_id)
+            .thread_name(t_name.to_string())
+            .content(format!("{}", r.args()))
+            .build()
+    }
+
+    pub fn t_id(&self) -> String {
+        format!("{}_{}", self.log_name, &self.id)
+    }
+
+    /// get EZRecord unique id
+    pub fn id(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.content.hash(&mut hasher);
+        self.time.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub fn trunks(&self, config: &EZLogConfig) -> Vec<EZRecord> {
+        let mut trunks: Vec<EZRecord> = Vec::new();
+        let mut split_content: Vec<char> = Vec::new();
+        let mut size = 0;
+        let chars = self.content.chars();
+        chars.for_each(|c| {
+            size += c.len_utf8();
+            if size > config.max_size as usize / 2 {
+                let ez = self
+                    .to_trunk_builder()
+                    .content(split_content.iter().collect::<String>())
+                    .build();
+                trunks.push(ez);
+                split_content.clear();
+                size = c.len_utf8();
+                split_content.push(c)
+            } else {
+                split_content.push(c);
+            }
+        });
+        if !split_content.is_empty() {
+            let ez = self
+                .to_trunk_builder()
+                .content(String::from_iter(&split_content))
+                .build();
+            trunks.push(ez);
+        }
+        trunks
+    }
+}
+
+/// [EZRecord]'s builder
+#[derive(Debug)]
+pub struct EZRecordBuilder {
+    record: EZRecord,
+}
+
+impl EZRecordBuilder {
+    pub fn new() -> EZRecordBuilder {
+        EZRecordBuilder::default()
+    }
+
+    pub fn level(&mut self, level: Level) -> &mut Self {
+        self.record.level = level;
+        self
+    }
+
+    pub fn target(&mut self, target: String) -> &mut Self {
+        self.record.target = target;
+        self
+    }
+
+    pub fn timestamp(&mut self, timestamp: i64) -> &mut Self {
+        let time = OffsetDateTime::from_unix_timestamp(timestamp)
+            .unwrap_or_else(|_| OffsetDateTime::now_utc());
+        self.record.time = time;
+        self
+    }
+
+    pub fn time(&mut self, time: OffsetDateTime) -> &mut Self {
+        self.record.time = time;
+        self
+    }
+
+    pub fn thread_id(&mut self, thread_id: usize) -> &mut Self {
+        self.record.thread_id = thread_id;
+        self
+    }
+
+    pub fn thread_name(&mut self, thread_name: String) -> &mut Self {
+        self.record.thread_name = thread_name;
+        self
+    }
+
+    pub fn content(&mut self, content: String) -> &mut Self {
+        self.record.content = content;
+        self
+    }
+
+    pub fn log_name(&mut self, name: String) -> &mut Self {
+        self.record.log_name = name;
+        self
+    }
+
+    pub fn build(&mut self) -> EZRecord {
+        self.record.id = self.record.id();
+        self.record.clone()
+    }
+}
+
+impl Default for EZRecordBuilder {
+    fn default() -> Self {
+        EZRecordBuilder {
+            record: EZRecord {
+                id: 0,
+                log_name: DEFAULT_LOG_NAME.to_string(),
+                level: Level::Info,
+                target: "".to_string(),
+                time: OffsetDateTime::now_utc(),
+                thread_id: thread_id::get(),
+                thread_name: thread::current().name().unwrap_or("unknown").to_string(),
+                content: "".to_string(),
+            },
+        }
+    }
+}

--- a/src/libs.rs
+++ b/src/libs.rs
@@ -1,2 +1,0 @@
-#[allow(unused_imports)]
-pub use ezlog::*;


### PR DESCRIPTION
- use protocol buffer's [varint](https://developers.google.com/protocol-buffers/docs/encoding) to encode/decode a dynamic length.
- refactor code, make lib.rs easy.