### PR TITLE
add create time info to file header.

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -72,14 +72,8 @@ fn get_config() -> EZLogConfig {
 #[allow(dead_code)]
 fn read_log_file_rewrite() {
     let log_config = get_config();
-    let (path, _mmap) = log_config
-        .create_mmap_file(OffsetDateTime::now_utc())
-        .unwrap();
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(&path)
-        .unwrap();
+    let (file, path, _mmap) = log_config.create_mmap_file().unwrap();
+
     let mut br = BufReader::new(&file);
 
     let mut buffer = Vec::new();

--- a/ezlog-core/src/lib.rs
+++ b/ezlog-core/src/lib.rs
@@ -846,6 +846,7 @@ mod tests {
         header.recorder_position = header.length().try_into().unwrap();
         let mut new_header = Header::create(&logger.config);
         new_header.timestamp = header.timestamp.clone();
+        new_header.rotate_time = header.rotate_time.clone();
         assert_eq!(header, new_header);
         logger.decode_record(&mut reader).unwrap();
         fs::remove_dir_all(&config.dir_path).unwrap_or_default();

--- a/ezlog-core/src/logger.rs
+++ b/ezlog-core/src/logger.rs
@@ -348,6 +348,8 @@ pub struct Header {
     pub(crate) cipher: CipherKind,
     /// timestamp
     pub(crate) timestamp: OffsetDateTime,
+    /// rotate time
+    pub(crate) rotate_time: Option<OffsetDateTime>,
 }
 
 impl Default for Header {
@@ -365,10 +367,13 @@ impl Header {
             compress: CompressKind::ZLIB,
             cipher: CipherKind::AES128GCM,
             timestamp: OffsetDateTime::now_utc(),
+            rotate_time: None,
         }
     }
 
     pub fn create(config: &EZLogConfig) -> Self {
+        let time = OffsetDateTime::now_utc();
+        let rotate_time = crate::rotate_time(time);
         Header {
             version: config.version,
             flag: 0,
@@ -376,6 +381,7 @@ impl Header {
             compress: config.compress,
             cipher: config.cipher,
             timestamp: OffsetDateTime::now_utc(),
+            rotate_time: Some(rotate_time),
         }
     }
 
@@ -446,6 +452,7 @@ impl Header {
             cipher: CipherKind::from(cipher),
             timestamp: OffsetDateTime::from_unix_timestamp(timestamp)
                 .unwrap_or_else(|_| OffsetDateTime::now_utc()),
+            rotate_time: None,
         })
     }
 

--- a/ezlog-core/src/logger.rs
+++ b/ezlog-core/src/logger.rs
@@ -4,11 +4,11 @@ use integer_encoding::VarIntWriter;
 use std::io::BufRead;
 use std::io::Read;
 use std::path::PathBuf;
+
 use std::{fs, io};
 use std::{io::Write, rc::Rc};
 
 use crate::events::Event::{self};
-use crate::Version;
 use crate::{
     appender::EZAppender,
     compress::ZlibCodec,
@@ -18,11 +18,12 @@ use crate::{
     RECORD_SIGNATURE_START,
 };
 use crate::{errors, event, V1_LOG_HEADER_SIZE};
+use crate::{Version, V2_LOG_HEADER_SIZE};
 use byteorder::ReadBytesExt;
 #[cfg(feature = "decode")]
 use integer_encoding::VarIntReader;
 use time::format_description::well_known::Rfc3339;
-use time::Date;
+use time::{Date, OffsetDateTime};
 
 type Result<T> = std::result::Result<T, LogError>;
 
@@ -309,21 +310,13 @@ impl EZLogger {
                                         }
                                     }
                                     Err(e) => {
-                                        event!(
-                                            Event::TrimError,
-                                            "judge file out of date error",
-                                            &e
-                                        )
+                                        event!(Event::TrimError, "judge file out of date error", &e)
                                     }
                                 }
                             };
                         }
                         Err(e) => {
-                            event!(
-                                Event::TrimError,
-                                "traversal file error",
-                                &e.into()
-                            )
+                            event!(Event::TrimError, "traversal file error", &e.into())
                         }
                     }
                 }
@@ -353,6 +346,8 @@ pub struct Header {
     pub(crate) compress: CompressKind,
     /// cipher kind
     pub(crate) cipher: CipherKind,
+    /// timestamp
+    pub(crate) timestamp: OffsetDateTime,
 }
 
 impl Default for Header {
@@ -364,11 +359,12 @@ impl Default for Header {
 impl Header {
     pub fn new() -> Self {
         Header {
-            version: Version::V1,
+            version: Version::V2,
             flag: 0,
-            recorder_position: Header::fixed_size() as u32,
+            recorder_position: V2_LOG_HEADER_SIZE as u32,
             compress: CompressKind::ZLIB,
             cipher: CipherKind::AES128GCM,
+            timestamp: OffsetDateTime::now_utc(),
         }
     }
 
@@ -376,17 +372,42 @@ impl Header {
         Header {
             version: config.version,
             flag: 0,
-            recorder_position: Header::fixed_size() as u32,
+            recorder_position: Header::length_compat(&config.version) as u32,
             compress: config.compress,
             cipher: config.cipher,
+            timestamp: OffsetDateTime::now_utc(),
         }
     }
 
-    pub fn fixed_size() -> usize {
-        V1_LOG_HEADER_SIZE
+    pub fn max_length() -> usize {
+        V2_LOG_HEADER_SIZE
+    }
+
+    #[inline]
+    pub fn length_compat(version: &Version) -> usize {
+        match version {
+            Version::V1 => V1_LOG_HEADER_SIZE,
+            Version::V2 => V2_LOG_HEADER_SIZE,
+            Version::UNKNOWN => 0,
+        }
+    }
+
+    pub fn length(&self) -> usize {
+        Self::length_compat(&self.version)
     }
 
     pub fn encode(&self, writer: &mut dyn Write) -> std::result::Result<(), io::Error> {
+        match self.version {
+            Version::V1 => self.encode_v1(writer),
+            Version::V2 => self.encode_v2(writer),
+            Version::UNKNOWN => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "unknown version",
+            )),
+        }
+    }
+
+    pub fn encode_v1(&self, writer: &mut dyn Write) -> std::result::Result<(), io::Error> {
         writer.write_all(crate::FILE_SIGNATURE)?;
         writer.write_u8(self.version.into())?;
         writer.write_u8(self.flag)?;
@@ -395,24 +416,36 @@ impl Header {
         writer.write_u8(self.cipher.into())
     }
 
+    pub fn encode_v2(&self, writer: &mut dyn Write) -> std::result::Result<(), io::Error> {
+        self.encode_v1(writer)?;
+        writer.write_i64::<BigEndian>(self.timestamp.unix_timestamp())
+    }
+
     pub fn decode(reader: &mut dyn Read) -> std::result::Result<Self, errors::LogError> {
         let mut signature = [0u8; 2];
         reader.read_exact(&mut signature)?;
-        let version = reader.read_u8()?;
+        let version = Version::from(reader.read_u8()?);
         let flag = reader.read_u8()?;
         let mut recorder_size = reader.read_u32::<BigEndian>()?;
-        if recorder_size < Header::fixed_size() as u32 {
-            recorder_size = Header::fixed_size() as u32;
+        if recorder_size < Header::length_compat(&version) as u32 {
+            recorder_size = Header::length_compat(&version) as u32;
         }
 
         let compress = reader.read_u8()?;
         let cipher = reader.read_u8()?;
+        let timestamp = if version == Version::V2 {
+            reader.read_i64::<BigEndian>()?
+        } else {
+            OffsetDateTime::now_utc().unix_timestamp()
+        };
         Ok(Header {
-            version: Version::from(version),
+            version,
             flag,
             recorder_position: recorder_size,
             compress: CompressKind::from(compress),
             cipher: CipherKind::from(cipher),
+            timestamp: OffsetDateTime::from_unix_timestamp(timestamp)
+                .unwrap_or_else(|_| OffsetDateTime::now_utc()),
         })
     }
 
@@ -423,7 +456,11 @@ impl Header {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.version == Version::UNKNOWN && self.recorder_position <= Header::fixed_size() as u32
+        self.version == Version::UNKNOWN || self.recorder_position <= self.length() as u32
+    }
+
+    pub fn has_record(&self) -> bool {
+        self.recorder_position > self.length() as u32
     }
 
     pub fn version(&self) -> &Version {


### PR DESCRIPTION
before this, mmap file name is base on date, the bad is, if crash happen before 24 o'clock, Process restart after 0 o'clock, the file name changed, and the log data lost.