### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["s1rius"]
 language = "en"
-multilingual = false
 src = "src"
 title = "ezlog documentation"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10